### PR TITLE
Allow specifying default clock speeds

### DIFF
--- a/src/config.cpp
+++ b/src/config.cpp
@@ -106,6 +106,17 @@ std::uint32_t Config::FindClockHzFromProfiles(std::uint64_t tid, ClockModule mod
                 }
             }
         }
+        for(auto profile: profiles)
+        {
+            std::map<std::tuple<std::uint64_t, ClockProfile, ClockModule>, std::uint32_t>::iterator it = this->profileMhzMap.find(std::make_tuple(std::uint64_t(0), profile, module));
+            if (it != this->profileMhzMap.end()) {
+                mhz = it->second;
+
+                if(mhz > 0) {
+                    break;
+                }
+            }
+        }
     }
 
     return std::max((std::uint32_t)0, mhz * 1000000);


### PR DESCRIPTION
I just duplicated the logic that looks through the configuration for title id 0; I'm not sure if there's a better sentinel value (maybe FFFFFFFFFFFFFFFF?)