### PR TITLE
Manager App: added Skin temperature to fix bug #24

### DIFF
--- a/manager/src/status_tab.cpp
+++ b/manager/src/status_tab.cpp
@@ -70,7 +70,7 @@ StatusTab::StatusTab(RefreshTask *refreshTask) :
     this->addView(serviceEnabledListItem);
 
     // Frequencies
-    brls::Header *hardwareHeader = new brls::Header("Hardware");
+    brls::Header *hardwareHeader = new brls::Header("Frequencies");
     this->addView(hardwareHeader);
 
     StatusGrid *frequenciesLayout = new StatusGrid();
@@ -87,6 +87,8 @@ StatusTab::StatusTab(RefreshTask *refreshTask) :
 
     this->addView(frequenciesLayout);
 
+    brls::Header *tempsHeader = new brls::Header("Temperatures");
+    this->addView(tempsHeader);
     // Temperatures
     StatusGrid *tempsLayout = new StatusGrid();
     tempsLayout->setSpacing(22);
@@ -94,6 +96,7 @@ StatusTab::StatusTab(RefreshTask *refreshTask) :
 
     this->socTempCell = new StatusCell("SOC", formatTemp(context.temps[SysClkThermalSensor_SOC]));
     this->pcbTempCell = new StatusCell("PCB", formatTemp(context.temps[SysClkThermalSensor_PCB]));
+    this->sknTempCell = new StatusCell("SKN", formatTemp(context.temps[SysClkThermalSensor_Skin]));
 
     if (context.temps[SysClkThermalSensor_SOC] > DANGEROUS_TEMP_THRESHOLD)
         this->socTempCell->setValueColor(DANGEROUS_TEMP_COLOR);
@@ -101,9 +104,13 @@ StatusTab::StatusTab(RefreshTask *refreshTask) :
     if (context.temps[SysClkThermalSensor_PCB] > DANGEROUS_TEMP_THRESHOLD)
         this->pcbTempCell->setValueColor(DANGEROUS_TEMP_COLOR);
 
-    tempsLayout->addView(new brls::Rectangle(nvgRGBA(0, 0, 0, 0)));
+    if (context.temps[SysClkThermalSensor_Skin] > DANGEROUS_TEMP_THRESHOLD)
+        this->sknTempCell->setValueColor(DANGEROUS_TEMP_COLOR);
+
+    //tempsLayout->addView(new brls::Rectangle(nvgRGBA(0, 0, 0, 0)));
     tempsLayout->addView(this->socTempCell);
     tempsLayout->addView(this->pcbTempCell);
+    tempsLayout->addView(this->sknTempCell);
 
     this->addView(tempsLayout);
 

--- a/manager/src/status_tab.h
+++ b/manager/src/status_tab.h
@@ -74,6 +74,7 @@ class StatusTab : public brls::List
 
         StatusCell *socTempCell;
         StatusCell *pcbTempCell;
+        StatusCell *sknTempCell;
 
         StatusCell *profileCell;
         StatusCell *tidCell;

--- a/overlay/Makefile
+++ b/overlay/Makefile
@@ -113,7 +113,7 @@ all: $(BUILD)
 $(BUILD):
 	@[ -d $@ ] || mkdir -p $@
 	@[ -d $(OUTDIR) ] || mkdir -p $(OUTDIR)
-	@$(MAKE) --no-print-directory -C $(BUILD) -f $(CURDIR)/Makefile
+	@MSYS2_ARG_CONV_EXCL="-D;$(MSYS2_ARG_CONV_EXCL)" $(MAKE) --no-print-directory -C $(BUILD) -f $(CURDIR)/Makefile
 
 #---------------------------------------------------------------------------------
 clean:


### PR DESCRIPTION
Added the missing Skin temperature to the Manager app and made some slight cosmetic changes to give temps their own header as seen in the screenshot : 

![sys-clk](https://user-images.githubusercontent.com/26387181/85213110-f6a5b800-b351-11ea-9341-8f5f44be227d.jpg)


This should resolve open bug #24 