### PR TITLE
Allow yielding to boost clocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,11 +101,12 @@ handheld_mem=800
 
 The `[values]` section allows you to alter timings in sys-clk, you should not need to edit any of these unless you know what you are doing. Possible values are:
 
-| Key                     | Desc                                                                          | Default |
-|:-----------------------:|-------------------------------------------------------------------------------|:-------:|
-|**temp_log_interval_ms** | Defines how often sys-clk log temperatures, in milliseconds (`0` to disable)  | 0 ms    |
-|**csv_write_interval_ms**| Defines how often sys-clk writes to the CSV, in milliseconds (`0` to disable) | 0 ms    |
-|**poll_interval_ms**     | Defines how fast sys-clk checks and applies profiles, in milliseconds         | 300 ms  |
+| Key                     | Desc                                                                          | Default  |
+|:-----------------------:|-------------------------------------------------------------------------------|:--------:|
+|**temp_log_interval_ms** | Defines how often sys-clk log temperatures, in milliseconds (`0` to disable)  | 0 ms     |
+|**csv_write_interval_ms**| Defines how often sys-clk writes to the CSV, in milliseconds (`0` to disable) | 0 ms     |
+|**poll_interval_ms**     | Defines how fast sys-clk checks and applies profiles, in milliseconds         | 300 ms   |
+|**override_boost_clk**   | Defines whether sys-clk should override boost mode clocks (`0` to disable)    | 1 (true) |
 
 
 ## Capping

--- a/common/include/sysclk/clocks.h
+++ b/common/include/sysclk/clocks.h
@@ -43,6 +43,7 @@ typedef enum
 typedef struct
 {
     uint8_t enabled;
+    uint8_t boostModeActive;
     uint64_t applicationId;
     SysClkProfile profile;
     uint32_t freqs[SysClkModule_EnumMax];
@@ -60,6 +61,8 @@ typedef struct
 
 #define SYSCLK_GPU_HANDHELD_MAX_HZ 460800000
 #define SYSCLK_GPU_UNOFFICIAL_CHARGER_MAX_HZ 768000000
+#define SYSCLK_GPU_BOOST_HZ 76800000
+#define SYSCLK_CPU_BOOST_HZ 1785000000
 
 extern uint32_t sysclk_g_freq_table_mem_hz[];
 extern uint32_t sysclk_g_freq_table_cpu_hz[];

--- a/common/include/sysclk/config.h
+++ b/common/include/sysclk/config.h
@@ -17,6 +17,7 @@ typedef enum {
     SysClkConfigValue_PollingIntervalMs = 0,
     SysClkConfigValue_TempLogIntervalMs,
     SysClkConfigValue_CsvWriteIntervalMs,
+    SysClkConfigValue_OverrideBoostClocks,
     SysClkConfigValue_EnumMax,
 } SysClkConfigValue;
 
@@ -34,6 +35,8 @@ static inline const char* sysclkFormatConfigValue(SysClkConfigValue val, bool pr
             return pretty ? "Temperature logging interval (ms)" : "temp_log_interval_ms";
         case SysClkConfigValue_CsvWriteIntervalMs:
             return pretty ? "CSV write interval (ms)" : "csv_write_interval_ms";
+        case SysClkConfigValue_OverrideBoostClocks:
+            return pretty ? "Whether or not to overwrite Boost clocks" : "override_boost_clk";
         default:
             return NULL;
     }
@@ -48,6 +51,8 @@ static inline uint64_t sysclkDefaultConfigValue(SysClkConfigValue val)
         case SysClkConfigValue_TempLogIntervalMs:
         case SysClkConfigValue_CsvWriteIntervalMs:
             return 0ULL;
+        case SysClkConfigValue_OverrideBoostClocks:
+            return 1ULL;
         default:
             return 0ULL;
     }
@@ -62,6 +67,8 @@ static inline uint64_t sysclkValidConfigValue(SysClkConfigValue val, uint64_t in
         case SysClkConfigValue_TempLogIntervalMs:
         case SysClkConfigValue_CsvWriteIntervalMs:
             return true;
+        case SysClkConfigValue_OverrideBoostClocks:
+            return 0 <= input && input <= 1;
         default:
             return false;
     }

--- a/manager/src/advanced_settings_tab.cpp
+++ b/manager/src/advanced_settings_tab.cpp
@@ -168,6 +168,8 @@ std::string AdvancedSettingsTab::getDescriptionForConfig(SysClkConfigValue confi
             return "How often to log temperatures (in milliseconds)\n\uE016  Use 0 to disable";
         case SysClkConfigValue_PollingIntervalMs:
             return "How fast to check and apply profiles (in milliseconds)";
+        case SysClkConfigValue_OverrideBoostClocks:
+            return "Whether sys-clk should override Boost mode clocks\n\uE016  Use 0 to disable";
         default:
             return "";
     }

--- a/sysmodule/src/clock_manager.cpp
+++ b/sysmodule/src/clock_manager.cpp
@@ -75,6 +75,7 @@ void ClockManager::Tick()
     if (this->RefreshContext() || this->config->Refresh())
     {
         std::uint32_t hz = 0;
+        std::uint64_t boostOverride = this->config->GetConfigValue(SysClkConfigValue_OverrideBoostClocks);
         for (unsigned int module = 0; module < SysClkModule_EnumMax; module++)
         {
             hz = this->context->overrideFreqs[module];
@@ -90,7 +91,7 @@ void ClockManager::Tick()
 
                 if (hz != this->context->freqs[module] && this->context->enabled)
                 {
-                    if (this->context->boostModeActive && module != SysClkModule_MEM)
+                    if (!boostOverride && this->context->boostModeActive && module != SysClkModule_MEM)
                     {
                         FileUtils::LogLine("[mgr] %s clock not set (Boost mode active)", Clocks::GetModuleName((SysClkModule)module, true));
                     }


### PR DESCRIPTION
This adds a feature to allow users to have sys-clk yield to boost clocks.  It adds a new `override_boost_clk` setting, which is enabled by default, matching the current sys-clk behavior of replacing clock speeds with the user's configuration regardless of their current value.

When `override_boost_clk` is set to 0 (off), then sys-clk will yield to the Boost mode CPU and GPU clocks, and will not overwrite them with the user's configuration.  It will still overwrite memory clocks per usual even in this mode.  Once sys-clk detects that Boost mode clocks have been deactivated, it automatically resumes overwriting clocks normally.

I have tested this myself and it all appears to be working as I've described.